### PR TITLE
Fix unique_id

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -1113,20 +1113,20 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
     unique_id = None
 
-    if model is None:
-        try:
-            miio_device = Device(host, token)
-            device_info = await hass.async_add_executor_job(miio_device.info)
-            model = device_info.model
-            unique_id = f"{model}-{device_info.mac_address}"
-            _LOGGER.info(
-                "%s %s %s detected",
-                model,
-                device_info.firmware_version,
-                device_info.hardware_version,
-            )
-        except DeviceException as ex:
-            raise PlatformNotReady from ex
+    try:
+        miio_device = Device(host, token)
+        device_info = await hass.async_add_executor_job(miio_device.info)
+        if model is None:
+          model = device_info.model
+          _LOGGER.info(
+              "%s %s %s detected",
+              model,
+              device_info.firmware_version,
+              device_info.hardware_version,
+          )
+        unique_id = f"{model}-{device_info.mac_address}"
+    except DeviceException as ex:
+        raise PlatformNotReady from ex
 
     if model in PURIFIER_MIOT:
         air_purifier = AirPurifierMiot(host, token)


### PR DESCRIPTION
Currently entity may not get unique_id if model is defined in config.
The fix solves this problem.